### PR TITLE
fix: remove invalid Helm OCI regex manager from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -95,15 +95,6 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Helm OCI chart versions in deploy.sh",
-      "fileMatch": ["scripts/deploy\\.sh$"],
-      "matchStrings": [
-        "helm pull (?<depName>oci://[^\\s]+)"
-      ],
-      "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
       "description": "Image versions in Helm values files",
       "fileMatch": ["helm-values/.*\\.yaml$"],
       "matchStrings": [


### PR DESCRIPTION
Removes the custom regex manager for Helm OCI chart versions that was causing Renovate to fail validation. The regex was missing a required currentValue capture group, and the actual helm pull command in deploy.sh doesn't specify versions anyway.

Helm chart updates will still be tracked via the built-in Helm manager and the packageRules configuration.

Fixes issue #2

@claude