### PR TITLE
chore: remove public access from EKS cluster and enhance
   security

### DIFF
--- a/eksctl/cluster.yaml
+++ b/eksctl/cluster.yaml
@@ -69,13 +69,6 @@ vpc:
 #         id: "subnet-xxxxx"
 #       us-east-1c:
 #         id: "subnet-xxxxx"
-#     public:
-#       us-east-1a:
-#         id: "subnet-xxxxx"
-#       us-east-1b:
-#         id: "subnet-xxxxx"
-#       us-east-1c:
-#         id: "subnet-xxxxx"
 
 # Managed Node Groups
 managedNodeGroups:

--- a/eksctl/cluster.yaml
+++ b/eksctl/cluster.yaml
@@ -53,7 +53,7 @@ vpc:
   cidr: 10.0.0.0/16
   clusterEndpoints:
     privateAccess: true
-    publicAccess: true
+    publicAccess: false
   nat:
     gateway: HighlyAvailable  # Multiple NAT gateways for HA
 


### PR DESCRIPTION
## Summary
   - Remove public access settings for EKS subnets to enhance security
   - Pin GitHub Actions to specific commit hashes for supply chain security
   - Improve .gitignore with comprehensive Terraform patterns
   - Add comprehensive project documentation (CONTRIBUTING.md, deployment guides, security
   architecture)